### PR TITLE
Update dependencies, use thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,15 @@ geo = ["geojson"]
 name = "rs_es"
 
 [dependencies]
-reqwest = "0.9"
+reqwest = { version = "0.10", features = ["blocking"] }
 log = "0.4"
 serde_json = "1.0"
 serde = {version = "1", features = ["derive"]}
-geojson = { version="0.16", optional=true}
+geojson = { version="0.19", optional=true}
+thiserror = "1.0.20"
+url = "2.1"
 
 [dev-dependencies]
-env_logger = "0.6"
-regex = "1.2"
+env_logger = "0.7"
+regex = "1.3"
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod units;
 
 use std::time;
 
-use reqwest::{header::CONTENT_TYPE, RequestBuilder, StatusCode, Url};
+use reqwest::{blocking::RequestBuilder, header::CONTENT_TYPE, StatusCode, Url};
 
 use serde::{de::DeserializeOwned, ser::Serialize};
 
@@ -55,7 +55,7 @@ pub trait EsResponse {
         R: DeserializeOwned;
 }
 
-impl EsResponse for reqwest::Response {
+impl EsResponse for reqwest::blocking::Response {
     fn status_code(&self) -> StatusCode {
         self.status()
     }
@@ -76,7 +76,7 @@ impl EsResponse for reqwest::Response {
 ///
 /// This function is exposed to allow extensions to certain operations, it is
 /// not expected to be used by consumers of the library
-fn do_req(resp: reqwest::Response) -> Result<reqwest::Response, EsError> {
+fn do_req(resp: reqwest::blocking::Response) -> Result<reqwest::blocking::Response, EsError> {
     let mut resp = resp;
     let status = resp.status();
     match status {
@@ -111,7 +111,7 @@ fn do_req(resp: reqwest::Response) -> Result<reqwest::Response, EsError> {
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: Url,
-    http_client: reqwest::Client,
+    http_client: reqwest::blocking::Client,
 }
 
 impl Client {
@@ -119,7 +119,7 @@ impl Client {
         &self,
         url: &str,
         action: impl FnOnce(Url) -> RequestBuilder,
-    ) -> Result<reqwest::Response, EsError> {
+    ) -> Result<reqwest::blocking::Response, EsError> {
         let url = self.full_url(url);
         let username = self.base_url.username();
         let mut method = action(url);
@@ -134,11 +134,11 @@ impl Client {
 /// Create a HTTP function for the given method (GET/PUT/POST/DELETE)
 macro_rules! es_op {
     ($n:ident,$cn:ident) => {
-        fn $n(&self, url: &str) -> Result<reqwest::Response, EsError> {
+        fn $n(&self, url: &str) -> Result<reqwest::blocking::Response, EsError> {
             log::info!("Doing {} on {}", stringify!($n), url);
             self.do_es_op(url, |url| self.http_client.$cn(url.clone()))
         }
-    }
+    };
 }
 
 /// Create a HTTP function with a request body for the given method
@@ -146,9 +146,10 @@ macro_rules! es_op {
 ///
 macro_rules! es_body_op {
     ($n:ident,$cn:ident) => {
-        fn $n<E>(&mut self, url: &str, body: &E) -> Result<reqwest::Response, EsError>
-            where E: Serialize {
-
+        fn $n<E>(&mut self, url: &str, body: &E) -> Result<reqwest::blocking::Response, EsError>
+        where
+            E: Serialize,
+        {
             log::info!("Doing {} on {}", stringify!($n), url);
             let json_string = serde_json::to_string(body)?;
             log::debug!("With body: {}", &json_string);
@@ -157,16 +158,16 @@ macro_rules! es_body_op {
                 self.http_client.$cn(url.clone()).body(json_string)
             })
         }
-    }
+    };
 }
 
 impl Client {
     /// Create a new client
-    pub fn init(url_s: &str) -> Result<Client, reqwest::UrlError> {
+    pub fn init(url_s: &str) -> Result<Client, EsError> {
         let url = Url::parse(url_s)?;
 
         Ok(Client {
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::blocking::Client::new(),
             base_url: url,
         })
     }
@@ -176,11 +177,11 @@ impl Client {
     pub fn init_with_timeout(
         url_s: &str,
         timeout: Option<time::Duration>,
-    ) -> Result<Client, reqwest::UrlError> {
+    ) -> Result<Client, EsError> {
         let url = Url::parse(url_s)?;
 
         Ok(Client {
-            http_client: reqwest::Client::builder()
+            http_client: reqwest::blocking::Client::builder()
                 .timeout(timeout)
                 .build()
                 .expect("Failed to build client"),
@@ -209,10 +210,7 @@ pub mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use super::{
-        Client,
-        error::EsError,
-    };
+    use super::{error::EsError, Client};
 
     // test setup
 
@@ -283,9 +281,11 @@ pub mod tests {
     pub fn clean_db(client: &mut Client, test_idx: &str) {
         match client.delete_index(test_idx) {
             // Ignore indices which don't exist yet
-            Err(EsError::EsError(ref msg)) if msg == "Unexpected status: 404 Not Found" => {},
-            Ok(_) => {},
-            e => { e.expect(&format!("Failed to clean db for index {:?}", test_idx)); },
+            Err(EsError::EsError { details }) if details == "Unexpected status: 404 Not Found" => {}
+            Ok(_) => {}
+            e => {
+                e.expect(&format!("Failed to clean db for index {:?}", test_idx));
+            }
         };
     }
 }

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -257,10 +257,9 @@ where
 
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }

--- a/src/operations/delete.rs
+++ b/src/operations/delete.rs
@@ -74,10 +74,9 @@ impl<'a, 'b> DeleteOperation<'a, 'b> {
         let response = self.client.delete_op(&url)?;
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }

--- a/src/operations/delete_index.rs
+++ b/src/operations/delete_index.rs
@@ -35,10 +35,9 @@ impl Client {
 
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -130,10 +130,9 @@ impl Client {
 
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 
@@ -144,10 +143,9 @@ impl Client {
 
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 
@@ -166,10 +164,9 @@ impl Client {
 
         match response.status_code() {
             StatusCode::OK => Ok(()),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }
@@ -242,11 +239,10 @@ pub mod tests {
                 .as_object()
                 .expect("by construction 'char_filter' should be a map")
                 .clone(),
-                tokenizer: serde_json::json! ({
-                })
-                .as_object()
-                .expect("by construction 'empty tokenizer' should be a map")
-                .clone(),
+                tokenizer: serde_json::json!({})
+                    .as_object()
+                    .expect("by construction 'empty tokenizer' should be a map")
+                    .clone(),
             },
         };
 

--- a/src/operations/refresh.rs
+++ b/src/operations/refresh.rs
@@ -51,10 +51,9 @@ impl<'a, 'b> RefreshOperation<'a, 'b> {
         let response = self.client.post_op(&url)?;
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }

--- a/src/operations/search/aggregations/bucket.rs
+++ b/src/operations/search/aggregations/bucket.rs
@@ -20,7 +20,7 @@ use std::{borrow::ToOwned, collections::HashMap, marker::PhantomData};
 
 use serde::{
     ser::{SerializeMap, Serializer},
-    Serialize, Deserialize,
+    Deserialize, Serialize,
 };
 use serde_json::Value;
 
@@ -840,12 +840,12 @@ macro_rules! add_aggs_ref {
         pub fn aggs_ref(&self) -> Option<&AggregationsResult> {
             self.aggs.as_ref()
         }
-    }
+    };
 }
 
 macro_rules! return_error {
     ($e:expr) => {
-        return Err(EsError::EsError($e));
+        return Err(EsError::EsError { details: $e });
     };
 }
 

--- a/src/operations/search/aggregations/common.rs
+++ b/src/operations/search/aggregations/common.rs
@@ -89,7 +89,7 @@ macro_rules! add_extra_option {
             self.0.extra.$e = Some(val.into());
             self
         }
-    }
+    };
 }
 
 impl<'a, E> Serialize for Agg<'a, E>
@@ -122,14 +122,16 @@ macro_rules! agg_as {
     ($n:ident,$st:ident,$tp:ident,$t:ident,$rt:ty) => {
         pub fn $n(&self) -> Result<&$rt, EsError> {
             match self {
-                AggregationResult::$st(ref res) => {
-                    match res {
-                        $tp::$t(ref res) => Ok(res),
-                        _ => Err(EsError::EsError(format!("Wrong type: {:?}", self)))
-                    }
+                AggregationResult::$st(ref res) => match res {
+                    $tp::$t(ref res) => Ok(res),
+                    _ => Err(EsError::EsError {
+                        details: format!("Wrong type: {:?}", self),
+                    }),
                 },
-                _ => Err(EsError::EsError(format!("Wrong type: {:?}", self)))
+                _ => Err(EsError::EsError {
+                    details: format!("Wrong type: {:?}", self),
+                }),
             }
         }
-    }
+    };
 }

--- a/src/operations/search/count.rs
+++ b/src/operations/search/count.rs
@@ -82,10 +82,9 @@ impl<'a, 'b> CountURIOperation<'a, 'b> {
         let response = self.client.get_op(&url)?;
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }
@@ -158,10 +157,9 @@ impl<'a, 'b> CountQueryOperation<'a, 'b> {
         let response = self.client.post_body_op(&url, &self.body)?;
         match response.status_code() {
             StatusCode::OK => Ok(response.read_response()?),
-            status_code => Err(EsError::EsError(format!(
-                "Unexpected status: {}",
-                status_code
-            ))),
+            status_code => Err(EsError::EsError {
+                details: format!("Unexpected status: {}", status_code),
+            }),
         }
     }
 }

--- a/src/query/compound.rs
+++ b/src/query/compound.rs
@@ -20,9 +20,7 @@ use serde::{Serialize, Serializer};
 
 use crate::{json::ShouldSkip, units::OneOrMany};
 
-use super::{
-    functions::FilteredFunction, functions::Function, MinimumShouldMatch, Query, ScoreMode,
-};
+use super::{functions::FilteredFunction, MinimumShouldMatch, Query, ScoreMode};
 
 /// BoostMode
 #[derive(Debug, Copy, Clone)]

--- a/src/units.rs
+++ b/src/units.rs
@@ -422,7 +422,11 @@ impl JsonVal {
             String(ref string) => JsonVal::String(string.clone()),
             Bool(b) => JsonVal::Boolean(*b),
             Number(ref i) => JsonVal::Number(i.clone()),
-            _ => return Err(EsError::EsError(format!("Not a JsonVal: {:?}", from))),
+            _ => {
+                return Err(EsError::EsError {
+                    details: format!("Not a JsonVal: {:?}", from),
+                })
+            }
         })
     }
 }


### PR DESCRIPTION
These changes bring a different error, ie from a custom error type to
a `thiserror` error.
It also update the dependencies, including reqwest. In order to limit
the change, we use reqwest::blocking.