### PR TITLE
Fix optional return values in BulkResult errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-es"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Ben Ashford"]
 license = "Apache-2.0"
 repository = "https://github.com/benashford/rs-es"

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -328,6 +328,8 @@ impl<'de> Deserialize<'de> for ActionResult {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct ActionResultInner {
+    #[serde(rename = "_id")]
+    pub id: String,
     #[serde(rename = "_index")]
     pub index: String,
     #[serde(rename = "_type")]

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -36,7 +36,7 @@ use crate::{
 
 use super::{
     common::{OptionVal, Options, VersionType},
-    ShardCountResult,
+    ActionError, ShardCountResult,
 };
 
 #[derive(Debug)]
@@ -338,6 +338,7 @@ pub struct ActionResultInner {
     #[serde(rename = "_shards")]
     pub shards: Option<ShardCountResult>,
     pub found: Option<bool>,
+    pub error: Option<ActionError>,
 }
 
 /// The result of a bulk operation

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -333,10 +333,10 @@ pub struct ActionResultInner {
     #[serde(rename = "_type")]
     pub doc_type: String,
     #[serde(rename = "_version")]
-    pub version: u64,
+    pub version: Option<u64>,
     pub status: u64,
     #[serde(rename = "_shards")]
-    pub shards: ShardCountResult,
+    pub shards: Option<ShardCountResult>,
     pub found: Option<bool>,
 }
 

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -87,7 +87,7 @@ pub struct ActionError {
     #[serde(rename = "type")]
     pub error_type: String,
     pub reason: String,
-    #[serde(rename = "cause_by")]
+    #[serde(rename = "caused_by")]
     pub cause: Option<CauseError>,
 }
 

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -22,7 +22,7 @@
 
 use std::borrow::Cow;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::util::StrJoin;
 
@@ -78,4 +78,23 @@ pub struct ShardCountResult {
 #[derive(Debug, Deserialize)]
 pub struct GenericResult {
     pub acknowledged: bool,
+}
+
+/// Information about an error that occured in a bulk operation
+/// See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ActionError {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub reason: String,
+    #[serde(rename = "cause_by")]
+    pub cause: Option<CauseError>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CauseError {
+    #[serde(rename = "type")]
+    pub cause_type: String,
+    pub reason: String,
+    pub failed: u64,
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -96,5 +96,4 @@ pub struct CauseError {
     #[serde(rename = "type")]
     pub cause_type: String,
     pub reason: String,
-    pub failed: u64,
 }


### PR DESCRIPTION
This fixes a deserialization error occuring when a bulk indexing operation contains an error. Elasticsearch specifies that `version` and `shard` are only present when it is successful.